### PR TITLE
Offline product retrieval

### DIFF
--- a/sentinelloader/sentinel2loader.py
+++ b/sentinelloader/sentinel2loader.py
@@ -143,10 +143,8 @@ class Sentinel2Loader:
             r = requests.get(url, auth=(self.user, self.password))
             if r.status_code != 200:
                 raise Exception("Could not get info on whether product is online. status=%s" % r.status_code)
-            logger.debug("{}".format(offline_product_count))
-            if r.text == False:
+            if r.text == "false":
                 offline_product_count += 1
-
         if offline_product_count != 0:
             # Calculate an estimate on how long in hours data retrieval requests would require to be sent for all offline files
             estimated_time = int(offline_product_count / 20) * 12 + offline_product_count % 20 * 0.5

--- a/sentinelloader/sentinel2loader.py
+++ b/sentinelloader/sentinel2loader.py
@@ -137,6 +137,21 @@ class Sentinel2Loader:
 #         g = gpd.GeoSeries(footprints)
 #         g.plot(cmap=plt.get_cmap('jet'), alpha=0.5)
 
+        offline_product_count = 0
+        for index, sp in products_df.loc[selectedTiles].iterrows():
+            url = "https://apihub.copernicus.eu/apihub/odata/v1/Products('%s')/Online/$value" % (sp['uuid'])
+            r = requests.get(url, auth=(self.user, self.password))
+            if r.status_code != 200:
+                raise Exception("Could not get info on whether product is online. status=%s" % r.status_code)
+            logger.debug("{}".format(offline_product_count))
+            if r.text == False:
+                offline_product_count += 1
+
+        if offline_product_count != 0:
+            # Calculate an estimate on how long in hours data retrieval requests would require to be sent for all offline files
+            estimated_time = int(offline_product_count / 20) * 12 + offline_product_count % 20 * 0.5
+            raise Exception("There are {} offline products out of {} required product(s). It will take {:.1f} hour(s) to request for all offline products to be brought online.".format(offline_product_count, len(products_df), estimated_time))
+
         #download tiles data
         tileFiles = []
         for index, sp in products_df.loc[selectedTiles].iterrows():


### PR DESCRIPTION
Currently, if an offline product is requested, sentinelloader will give an error that the metadata was unable to be retrieved. However, it is difficult to tell whether this error was caused by an offline product, or if the metadata file is just not present in the online product. 

Ultimately, we want to be able to check for offline products among the products we need, request for offline products to be brought online, and download all products when they're ready. 
As a first step towards that goal, this update will check for whether the required products are offline or online, and raise an error if one or more products are offline. This error informs the user that some of the needed products offline, and gives an estimate on how long it would take to request for products to be brought online. If all products are online, the products are downloaded and the process proceeds as usual.